### PR TITLE
update to alpine 3.11.0

### DIFF
--- a/radclient/Dockerfile
+++ b/radclient/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9.4
+FROM alpine:3.11.0
 
 RUN apk add --no-cache freeradius-radclient
 COPY test.conf /root/test.conf

--- a/radiusd/Dockerfile
+++ b/radiusd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9.4
+FROM alpine:3.11.0
 
 # Mysteriously, some files in /etc/raddb have incorrect ownership.
 # Therefore we have to fix it up, and we have to do so


### PR DESCRIPTION
renovate-bot hasn't opened a PR yet.
Maybe it's because 3.9.4 is the most recent 3.9 version.

Bump to 3.11.0 and see if renovate-bot then bumps to 3.11.z.